### PR TITLE
Fix file serving when query parameters are used

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,9 @@ export default function livery(dir = '.', options = {}) {
 			}
 		}
 
-		send(req, req.url, { root: rootPath }).on('error', serveSpa).pipe(res);
+		// Parse the incoming URL to get just the pathname, so we can serve up the file
+		const urlObj = new URL(req.url, 'http://fakehost')
+		send(req, urlObj.pathname, { root: rootPath }).on('error', serveSpa).pipe(res);
 	});
 
 	httpServer.on('error', console.error);


### PR DESCRIPTION
When attempting to use this with a project that used query parameters, I found that the server was giving a 404 because it was trying to serve a path that included the query parameters.

This patch parses the URL and uses `url.pathname` for that instead of just `req.url`.